### PR TITLE
fix:bug reading local files

### DIFF
--- a/middleware/params.go
+++ b/middleware/params.go
@@ -3,12 +3,26 @@ package middleware
 import (
 	"net/url"
 
+	"github.com/gorilla/schema"
 	"github.com/kataras/iris/v12"
 	"github.com/lampnick/doctron/common"
 )
 
 func CheckParams(ctx iris.Context) {
-	webUrl := ctx.URLParam("url")
+	type Param struct {
+		Url string `schema:"url,omitempty" validate:"required,url"`
+	}
+	dto := Param{}
+	decoder := schema.NewDecoder()
+	err := decoder.Decode(&dto, ctx.Request().URL.Query()) 
+	if err != nil {
+		outputDTO := common.NewDefaultOutputDTO(nil)
+		outputDTO.Code = common.InvalidUrl
+		outputDTO.Message = err.Error()
+		_, _ = common.NewJsonOutput(ctx, outputDTO)
+		return
+	}
+	webUrl := dto.Url
 	if webUrl == "" {
 		outputDTO := common.NewDefaultOutputDTO(nil)
 		outputDTO.Code = common.InvalidUrl


### PR DESCRIPTION
when you get `http://localhost:8080/convert/html2pdf?u=doctron&p=lampnick&url=https://www.baidu.com&url=file:///etc/hosts`, you can get your local file

`CheckParams`check the first url but `decoder.Decode(requestDTO, ctx.Request().URL.Query())` use the last url
